### PR TITLE
fixed some bugs. Ref #10

### DIFF
--- a/tools/translate_with_equation/main.css
+++ b/tools/translate_with_equation/main.css
@@ -1,5 +1,5 @@
 h1 {
-    font-size: 25px;
+    font-size: 23px;
 }
 
 h2 {


### PR DESCRIPTION
# 内容

以下のバグを修正

## ```\left```, ```\right```に関するバグ

Issue #10 に記述されたバグ．2つ目の解決策である「```\left```, ```\right```の数が揃わなければ，不足分を足す」を採用．

## ブロック数式（インライン数式でない方）における，改行が複数発生するバグ

Pull #9 でカンマ・ピリオドの前後で数式を分割するようにしたが，  
ブロック数式でこの処理をすると，複数のブロック数式に分けられることになる．  
ブロック数式は数式を表示されるために改行が行われるので，分割数分の改行が行われてしまう．

「カンマ・ピリオドの前後で数式を分割する」という処理は，インライン数式でのみ必要と考えて，  
ブロック数式に対してはその処理を行わないようにした．

## EQがeqになり，数式が代入されないバグ

```EQxxxx```を翻訳しても```EQxxxx```になると考えていたが，```eqxxxx```に変換されるケースを観測したので，    
```eqxxxx```になった場合にも対応した．